### PR TITLE
🐛 fix(kanbanEditor): update updateTextDocument return type to Promise<boolean>

### DIFF
--- a/src/kanbanEditor.ts
+++ b/src/kanbanEditor.ts
@@ -130,11 +130,11 @@ export class KanbanEditorProvider implements vscode.CustomTextEditorProvider {
 			</html>`;
   }
 
-  private async updateTextDocument(document: vscode.TextDocument, kanban: Kanban) {
+  private async updateTextDocument(document: vscode.TextDocument, kanban: Kanban): Promise<boolean> {
     const text = toJson(kanban);
 
     if (document.getText() === text) {
-      return;
+      return true;
     }
 
     const edit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
The updateTextDocument method now properly returns Promise<boolean> to match its async nature and provide consistent return values.

🤖 Generated with [Claude Code](https://claude.ai/code)